### PR TITLE
Remove patch part of version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ py_modules =
 
 setup_requires = setuptools_scm[toml] >= 4
 
-python_requires = >=3.6.*
+python_requires = >=3.6
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Fails with newer setuptools releases:

setuptools.extern.packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=3.6.*'